### PR TITLE
Allow table allowlisting and some additional configuration options.

### DIFF
--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -1,17 +1,17 @@
 Transform: 'AWS::Serverless-2016-10-31'
 Metadata:
   'AWS::ServerlessRepo::Application':
-    Name: AthenaDynamoDBConnector
+    Name: AthenaDynamoDBConnector-Porsche
     Description: 'This connector enables Amazon Athena to communicate with DynamoDB, making your tables accessible via SQL.'
-    Author: 'default author'
+    Author: 'Porsche - Insights BI'
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
     ReadmeUrl: README.md
     Labels:
       - athena-federation
-    HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 1.0.0
-    SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
+    HomePageUrl: 'https://github.com/porscheofficial/aws-athena-query-federation'
+    SemanticVersion: 2022.47.1
+    SourceCodeUrl: 'https://github.com/porscheofficial/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
     Description: 'This is the name of the lambda function that will be created. This name must satisfy the pattern ^[a-z0-9-_]{1,64}$'

--- a/athena-dynamodb/athena-dynamodb.yaml
+++ b/athena-dynamodb/athena-dynamodb.yaml
@@ -10,7 +10,7 @@ Metadata:
     Labels:
       - athena-federation
     HomePageUrl: 'https://github.com/awslabs/aws-athena-query-federation'
-    SemanticVersion: 2022.47.1
+    SemanticVersion: 1.0.0
     SourceCodeUrl: 'https://github.com/awslabs/aws-athena-query-federation'
 Parameters:
   AthenaCatalogName:
@@ -24,6 +24,28 @@ Parameters:
     Description: 'The prefix within SpillBucket where this function can spill data.'
     Type: String
     Default: athena-spill
+  SpillPutRequestHeaders:
+    Description: '(Optional) A JSON encoded map of request headers and values for the Amazon S3 putObject request that is used for spilling. (for example, {"x-amz-server-side-encryption" : "aws:kms"}).'
+    Type: String
+  DisableGlue:
+    Description: "(Optional) If present and set to 'true', the connector does not attempt to retrieve supplemental metadata from AWS Glue."
+    Default: 'false'
+    Type: String
+    AllowedValues:
+      - true
+      - false
+  DisableProjectionAndCasing:
+    Description: "(Optional) Disables projection and casing. Use if you want to query DynamoDB tables that have casing in their column names and you do not want to specify a columnMapping property on your AWS Glue table. Can be set to 'auto' or 'always', set to 'auto' by default. See documentation for more information."
+    Default: 'auto'
+    Type: String
+    AllowedValues:
+      - auto
+      - always
+  AllowedTables:
+    Description: "(Optional) List of ';' delimited table names that should be fetched from DynamoDB, no other tables will be scanned if supplied."
+    Type: String
+    AllowedPattern: ^(?!.*;$)[^;]*(;[^;]*)*$
+    Default: ""
   LambdaTimeout:
     Description: 'Maximum Lambda invocation runtime in seconds. (min 1 - 900 max)'
     Default: 900
@@ -51,6 +73,8 @@ Parameters:
 
 Conditions:
   HasKMSKeyId: !Not [!Equals [!Ref KMSKeyId, ""]]
+  HasAllowedTables: !Not [!Equals [!Ref AllowedTables, ""]]
+  HasSpillPutRequestHeaders: !Not [!Equals [!Ref SpillPutRequestHeaders, ""]]
   NotHasLambdaRole: !Equals [!Ref LambdaRole, ""]
   HasPermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryARN, "" ] ]
   CreateKMSPolicy: !And [!Condition HasKMSKeyId, !Condition NotHasLambdaRole]
@@ -62,6 +86,10 @@ Resources:
       Environment:
         Variables:
           disable_spill_encryption: !Ref DisableSpillEncryption
+          disable_projection_and_casing: !Ref DisableProjectionAndCasing
+          disable_glue: !Ref DisableGlue
+          spill_put_request_headers: !If [HasSpillPutRequestHeaders, !Ref SpillPutRequestHeaders, !Ref "AWS::NoValue"]
+          allowed_tables: !If [HasAllowedTables, !Ref AllowedTables, !Ref "AWS::NoValue"]
           spill_bucket: !Ref SpillBucket
           spill_prefix: !Ref SpillPrefix
           kms_key_id: !If [HasKMSKeyId, !Ref KMSKeyId, !Ref "AWS::NoValue"]

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -71,6 +71,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,6 +120,7 @@ public class DynamoDBMetadataHandler
     @VisibleForTesting
     static final int MAX_SPLITS_PER_REQUEST = 1000;
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBMetadataHandler.class);
+    private static final String ALLOWED_TABLES_ENV = "allowed_tables";
     static final String DYNAMODB = "dynamodb";
     private static final String SOURCE_TYPE = "ddb";
     // defines the value that should be present in the Glue Database URI to enable the DB for DynamoDB.
@@ -143,7 +145,14 @@ public class DynamoDBMetadataHandler
                 .build();
         this.glueClient = getAwsGlue();
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
-        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient);
+
+        String allowedTablesEnvStr = configOptions.getOrDefault(ALLOWED_TABLES_ENV, "");
+        List<String> allowedTables = new ArrayList<>();
+        if (!allowedTablesEnvStr.isEmpty()) {
+            allowedTables = Arrays.asList(allowedTablesEnvStr.split(";", -1));
+        }
+
+        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient, allowedTables);
     }
 
     @VisibleForTesting
@@ -161,7 +170,7 @@ public class DynamoDBMetadataHandler
         this.glueClient = glueClient;
         this.ddbClient = ddbClient;
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
-        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient);
+        this.tableResolver = new DynamoDBTableResolver(invoker, ddbClient, new ArrayList<>());
     }
 
     /**
@@ -197,6 +206,7 @@ public class DynamoDBMetadataHandler
      * <p>
      * If the specified schema is "default", this also returns an intersection with actual tables in DynamoDB.
      * Pagination only implemented for DynamoDBTableResolver.listTables()
+     *
      * @see GlueMetadataHandler
      */
     @Override
@@ -210,7 +220,7 @@ public class DynamoDBMetadataHandler
             try {
                 // does not validate that the tables are actually DDB tables
                 combinedTables.addAll(super.doListTables(allocator, new ListTablesRequest(request.getIdentity(), request.getQueryId(), request.getCatalogName(),
-                                request.getSchemaName(), null, UNLIMITED_PAGE_SIZE_VALUE), TABLE_FILTER).getTables());
+                        request.getSchemaName(), null, UNLIMITED_PAGE_SIZE_VALUE), TABLE_FILTER).getTables());
             }
             catch (RuntimeException e) {
                 logger.warn("doListTables: Unable to retrieve tables from AWSGlue in database/schema {}", request.getSchemaName(), e);

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/DynamoDBMetadataHandler.java
@@ -206,7 +206,6 @@ public class DynamoDBMetadataHandler
      * <p>
      * If the specified schema is "default", this also returns an intersection with actual tables in DynamoDB.
      * Pagination only implemented for DynamoDBTableResolver.listTables()
-     *
      * @see GlueMetadataHandler
      */
     @Override
@@ -220,7 +219,7 @@ public class DynamoDBMetadataHandler
             try {
                 // does not validate that the tables are actually DDB tables
                 combinedTables.addAll(super.doListTables(allocator, new ListTablesRequest(request.getIdentity(), request.getQueryId(), request.getCatalogName(),
-                        request.getSchemaName(), null, UNLIMITED_PAGE_SIZE_VALUE), TABLE_FILTER).getTables());
+                                request.getSchemaName(), null, UNLIMITED_PAGE_SIZE_VALUE), TABLE_FILTER).getTables());
             }
             catch (RuntimeException e) {
                 logger.warn("doListTables: Unable to retrieve tables from AWSGlue in database/schema {}", request.getSchemaName(), e);

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
@@ -48,7 +48,7 @@ import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.U
  * which may have captial letters in them without issue. It does so by fetching all table names and doing
  * a case insensitive search over them. It will first try to do a targeted get to reduce the penalty for
  * tables which don't have capitalization.
- * <p>
+ *
  * TODO add caching
  */
 public class DynamoDBTableResolver

--- a/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
+++ b/athena-dynamodb/src/main/java/com/amazonaws/athena/connectors/dynamodb/resolver/DynamoDBTableResolver.java
@@ -48,7 +48,7 @@ import static com.amazonaws.athena.connector.lambda.metadata.ListTablesRequest.U
  * which may have captial letters in them without issue. It does so by fetching all table names and doing
  * a case insensitive search over them. It will first try to do a targeted get to reduce the penalty for
  * tables which don't have capitalization.
- *
+ * <p>
  * TODO add caching
  */
 public class DynamoDBTableResolver
@@ -58,11 +58,13 @@ public class DynamoDBTableResolver
     private AmazonDynamoDB ddbClient;
     // used to handle Throttling events using an AIMD strategy for congestion control.
     private ThrottlingInvoker invoker;
+    private List<String> allowedTables;
 
-    public DynamoDBTableResolver(ThrottlingInvoker invoker, AmazonDynamoDB ddbClient)
+    public DynamoDBTableResolver(ThrottlingInvoker invoker, AmazonDynamoDB ddbClient, List<String> allowedTables)
     {
         this.invoker = invoker;
         this.ddbClient = ddbClient;
+        this.allowedTables = allowedTables;
     }
 
     /**
@@ -88,7 +90,21 @@ public class DynamoDBTableResolver
             ListTablesRequest ddbRequest = new ListTablesRequest()
                     .withExclusiveStartTableName(nextToken).withLimit(limit);
             ListTablesResult result = invoker.invoke(() -> ddbClient.listTables(ddbRequest));
-            tables.addAll(result.getTableNames());
+            List<String> resultTableNames = result.getTableNames();
+            if (!allowedTables.isEmpty()) {
+                resultTableNames.forEach(tableName -> {
+                    if (allowedTables.contains(tableName)) {
+                        tables.add(tableName);
+                    }
+                    else {
+                        logger.warn("{} excluded from tables-to-scan", tableName);
+                    }
+                });
+            }
+            else {
+                tables.addAll(resultTableNames);
+            }
+
             nextToken = result.getLastEvaluatedTableName();
         }
         while (nextToken != null && pageSize == UNLIMITED_PAGE_SIZE_VALUE);


### PR DESCRIPTION
## 📑 Description
Originally the connector lists all of the DynamoDB tables inside an account and then tries to scan/query them. The issue with this is that there is no way of preventing confidential tables from showing up inside Athena. Since it is not possible to block access through Athena and denying scan/query permissions to the tables results in a runtime exception, we decided to add the functionality to explicitly define the list of DynamoDB tables that you would like to show.

This list of tables can be defined through the `AllowedTables` template parameter and will be passed onto the connector Lambda as an environment variable. If this parameter is not defined then the connector will behave as originally designed and show all of the tables in the account.

Additionally 3 other template parameters were added, namely `DisableGlue`, `SpillPutRequestHeaders` and `DisableProjectionAndCasing`. We are already using 2 of these, but with some custom workarounds, so this will lift some weight off our shoulders. We have tried contacting AWS to add support for these, but they were keen on keeping the template simple. The functionality for these were already present in the connector codes, only the template values were missing.

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
